### PR TITLE
[feature] adding add_spikes option for treadmill routines, load_session

### DIFF
--- a/cottage_analysis/analysis/spheres/spheres.py
+++ b/cottage_analysis/analysis/spheres/spheres.py
@@ -651,6 +651,7 @@ def regenerate_frames_all_recordings(
     harp_is_in_recording=True,
     use_onix=False,
     ephys_kwargs=None,
+    add_spikes=False,
     do_regenerate_frames=True,
     verbose=True,
 ):
@@ -683,6 +684,7 @@ def regenerate_frames_all_recordings(
              False.
         ephys_kwargs (dict): Keyword arguments for generate_spike_rate_df.
             `return_multiunit` or `exp_sd` for instance. Defaults to None.
+        add_spikes (bool): if True, add spikes to trials_df for two_photon recordings. Defaults to False.
         do_regenerate_frames (bool): if True, regenerate frames. Defaults to True.
         verbose (bool): if True, print progress. Defaults to True.
 
@@ -740,6 +742,7 @@ def regenerate_frames_all_recordings(
             exclude_datasets,
             return_volumes,
             ephys_kwargs,
+            add_spikes=add_spikes,
             verbose=True,
         )
 

--- a/cottage_analysis/analysis/treadmill.py
+++ b/cottage_analysis/analysis/treadmill.py
@@ -151,6 +151,7 @@ def sync_all_recordings(
     do_process_imaging_df=True,
     protocol_base=None,
     treadmill_params=None,
+    add_spikes=False,
 ):
     """Concatenate synchronisation results for all recordings in a session.
 
@@ -200,6 +201,7 @@ def sync_all_recordings(
             Keys: ``steps_per_rev`` (int), ``microstepping`` (float),
             ``wheel_radius`` (float, cm), ``actual_motor_speed`` (dict mapping
             nominal to actual speed). Defaults to ``DEFAULT_TREADMILL_PARAMS``.
+        add_spikes (bool, optional): If True, add spikes to the neurons dataframe. Defaults to False.
 
     Returns:
         (pd.DataFrame, pd.DataFrame): tuple of two dataframes, one concatenated vs_df
@@ -260,6 +262,7 @@ def sync_all_recordings(
                 filter_datasets=filter_datasets,
                 exclude_datasets=exclude_datasets,
                 return_volumes=return_volumes,
+                add_spikes=add_spikes,
             )
         else:
             assert ephys_kwargs is not None, "Must provide ephys_kwargs if non-2p"
@@ -304,7 +307,7 @@ def sync_all_recordings(
             )
 
         trials_df = spheres.generate_trials_df(
-            recording=recording, imaging_df=imaging_df
+            recording=recording, imaging_df=imaging_df, add_spikes=add_spikes,
         )
 
         # Slice the continuous simulated trace correctly into the cropped trials

--- a/cottage_analysis/pipelines/pipeline_utils.py
+++ b/cottage_analysis/pipelines/pipeline_utils.py
@@ -156,6 +156,7 @@ def load_session(
     ephys_kwargs=None,
     return_neurons_df=True,
     treadmill_params=None,
+    add_spikes=False,
 ):
     """Load data from a single session.
 
@@ -182,6 +183,7 @@ def load_session(
         treadmill_params (dict, optional): Hardware parameters for the treadmill rig.
             Passed to ``treadmill.sync_all_recordings``. Defaults to
             ``DEFAULT_TREADMILL_PARAMS``.
+        add_spikes (bool, optional): Whether to add spikes to the neurons dataframe. Defaults to False.
 
     Returns:
         neurons_df (pd.DataFrame): neurons_df dataframe.
@@ -224,6 +226,7 @@ def load_session(
             return_volumes=True,
             ephys_kwargs=ephys_kwargs,
             treadmill_params=treadmill_params,
+            add_spikes=add_spikes,
         )
     else:
         vs_df_all, trials_df_all = spheres.sync_all_recordings(
@@ -237,6 +240,7 @@ def load_session(
             photodiode_protocol=photodiode_protocol,
             return_volumes=True,
             ephys_kwargs=ephys_kwargs,
+            add_spikes=add_spikes,
         )
     out = [neurons_ds, neurons_df, vs_df_all, trials_df_all]
     if regenerate_frames:
@@ -253,6 +257,7 @@ def load_session(
             resolution=5,
             verbose=False,
             ephys_kwargs=ephys_kwargs,
+            add_spikes=add_spikes,
         )
         out = out + [frames_all, imaging_df_all]
     return tuple(out)


### PR DESCRIPTION
Adding deconvolved spikes to `trials_df` when loading a session of any `protocol_base`